### PR TITLE
Fix static properties (#35)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /tests/Assets/workspace
 /composer.lock
 /.php_cs.cache
+/.vscode
 /stubs
 /.phpunit.result.cache
 .phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "phpactor/source-code-filesystem": "~0.1.5",
         "phpactor/source-code-filesystem-extension": "^0.1.3",
         "phpactor/text-document": "^1.1.3",
-        "phpactor/worse-reflection": "^0.4",
+        "phpactor/worse-reflection": "^0.4.4",
         "phpactor/worse-reflection-extension": "^0.2.0",
         "thecodingmachine/safe": "^1.0"
     },

--- a/lib/Adapter/Tolerant/Indexer/ClassLikeReferenceIndexer.php
+++ b/lib/Adapter/Tolerant/Indexer/ClassLikeReferenceIndexer.php
@@ -5,10 +5,12 @@ namespace Phpactor\Indexer\Adapter\Tolerant\Indexer;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\Expression\CallExpression;
 use Microsoft\PhpParser\Node\QualifiedName;
+use Microsoft\PhpParser\Node\TraitUseClause;
 use Phpactor\Indexer\Model\Index;
 use Phpactor\Indexer\Model\RecordReference;
 use Phpactor\Indexer\Model\Record\ClassRecord;
 use Phpactor\Indexer\Model\Record\FileRecord;
+use Phpactor\WorseReflection\Bridge\TolerantParser\Patch\TolerantQualifiedNameResolver;
 use SplFileInfo;
 
 class ClassLikeReferenceIndexer extends AbstractClassLikeIndexer
@@ -48,10 +50,13 @@ class ClassLikeReferenceIndexer extends AbstractClassLikeIndexer
     public function index(Index $index, SplFileInfo $info, Node $node): void
     {
         assert($node instanceof QualifiedName);
+        
+        $name =
+            $node->parent->parent instanceof TraitUseClause ?
+                TolerantQualifiedNameResolver::getResolvedName($node) :
+                $node->getResolvedName();
 
-        $name = $node->getResolvedName() ? $node->getResolvedName() : null;
-
-        if (null === $name) {
+        if (empty($name)) {
             return;
         }
 

--- a/lib/Adapter/Tolerant/Indexer/MemberIndexer.php
+++ b/lib/Adapter/Tolerant/Indexer/MemberIndexer.php
@@ -106,7 +106,7 @@ class MemberIndexer implements TolerantIndexer
             return (string)$memberName->getText($node->getFileContents());
         }
 
-        return $memberName->getText();
+        return $memberName->getName();
     }
 
     private function indexMemberAccessExpression(Index $index, SplFileInfo $info, MemberAccessExpression $node): void

--- a/tests/Adapter/ReferenceFinder/IndexedReferenceFinderTest.php
+++ b/tests/Adapter/ReferenceFinder/IndexedReferenceFinderTest.php
@@ -19,6 +19,7 @@ class IndexedReferenceFinderTest extends IntegrationTestCase
 
     /**
      * @dataProvider provideClasses
+     * @dataProvider provideTraits
      * @dataProvider provideFunctions
      * @dataProvider provideMembers
      * @dataProvider provideUnknown
@@ -98,6 +99,35 @@ class Bar extends Foo {}
 Bar::bar();
 EOT
         ,
+            2
+        ];
+    }
+
+    
+    /**
+     * @return Generator<mixed>
+     */
+    public function provideTraits(): Generator
+    {
+        yield 'single trait' => [
+            <<<'EOT'
+// File: project/subject.php
+<?php class Foo { use Ba<>r; };
+EOT
+            ,
+            1
+        ];
+
+        yield 'implementation' => [
+            <<<'EOT'
+// File: project/subject.php
+<?php class Foo { use Ba<>r; };
+
+// File: project/other.php
+<?php
+$b = new Foo();
+EOT
+            ,
             2
         ];
     }
@@ -188,6 +218,21 @@ EOT
 EOT
         ,
             2, 4 // total number is multipled due to implementation recursion
+        ];
+
+        yield 'static properties' => [
+            <<<'EOT'
+// File: project/foobar.php
+<?php class Foobar { public static $staticProp; function f(){ self::$staticProp = 5; } }
+
+// File: project/subject.php
+<?php Foobar::$st<>aticProp = 5;
+
+// File: project/class1.php
+<?php var $b = Foobar::$staticProp;
+EOT
+        ,
+            3
         ];
     }
 

--- a/tests/Adapter/Tolerant/Indexer/ClassLikeReferenceIndexerTest.php
+++ b/tests/Adapter/Tolerant/Indexer/ClassLikeReferenceIndexerTest.php
@@ -73,9 +73,27 @@ class ClassLikeReferenceIndexerTest extends TolerantIndexerTestCase
             [0, 0, 1]
         ];
 
+        yield 'class multiple implements 2' => [
+            "// File: src/file1.php\n<?php class Barfoo implements Foo,Bar {};",
+            'Bar',
+            [0, 0, 1]
+        ];
+
         yield 'abstract class implements' => [
             "// File: src/file1.php\n<?php abstract class Barfoo implements Foobar,Barfoo {};",
             'Foobar',
+            [0, 0, 1]
+        ];
+
+        yield 'use trait (basic)' => [
+            "// File: src/file1.php\n<?php class C { use T; }",
+            'T',
+            [0, 0, 1]
+        ];
+
+        yield 'use trait (namespaced)' => [
+            "// File: src/file1.php\n<?php use N\T; class C { use T; }",
+            'N\T',
             [0, 0, 1]
         ];
     }

--- a/tests/Adapter/Tolerant/Indexer/MemberIndexerTest.php
+++ b/tests/Adapter/Tolerant/Indexer/MemberIndexerTest.php
@@ -86,7 +86,7 @@ class MemberIndexerTest extends TolerantIndexerTestCase
 
         yield MemberRecord::TYPE_PROPERTY => [
             "// File: src/file1.php\n<?php Foobar::\$foobar;",
-            MemberReference::create(MemberRecord::TYPE_PROPERTY, 'Foobar', '$foobar'),
+            MemberReference::create(MemberRecord::TYPE_PROPERTY, 'Foobar', 'foobar'),
             [ 0, 0, 1 ]
         ];
 
@@ -100,6 +100,12 @@ class MemberIndexerTest extends TolerantIndexerTestCase
             "// File: src/file1.php\n<?php class Foobar { function bar() {} function foo() { self::bar(); } }",
             MemberReference::create(MemberRecord::TYPE_METHOD, 'Foobar', 'bar'),
             [ 0, 0, 1 ]
+        ];
+
+        yield 'self (property)' => [
+            "// File: src/file1.php\n<?php class Foobar { static \$barProp; function foo() { self::\$barProp = 5; \$var1 = self::\$barProp; } }",
+            MemberReference::create(MemberRecord::TYPE_PROPERTY, 'Foobar', 'barProp'),
+            [ 0, 0, 2 ]
         ];
 
         yield 'parent' => [

--- a/tests/Adapter/Tolerant/Indexer/TraitUseClauseIndexerTest.php
+++ b/tests/Adapter/Tolerant/Indexer/TraitUseClauseIndexerTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Phpactor\Indexer\Tests\Adapter\Tolerant\Indexer;
+
+use Generator;
+use Phpactor\Indexer\Adapter\Tolerant\Indexer\TraitUseClauseIndexer;
+use Phpactor\Indexer\Tests\Adapter\Tolerant\TolerantIndexerTestCase;
+
+class TraitUseClauseIndexerTest extends TolerantIndexerTestCase
+{
+    /**
+    * @dataProvider provideImplementations
+    */
+    public function testImplementations(string $manifest, string $fqn, int $expectedCount): void
+    {
+        $this->workspace()->reset();
+        $this->workspace()->loadManifest($manifest);
+        $agent = $this->runIndexer(new TraitUseClauseIndexer(), 'src');
+        self::assertEquals($expectedCount, count($agent->query()->class()->implementing($fqn)));
+    }
+
+    /**
+    * @return Generator<mixed>
+    */
+    public function provideImplementations(): Generator
+    {
+        yield 'use trait (basic)' => [
+            "// File: src/file1.php\n<?php namespace N; use T; class C { use T; }",
+            'T',
+            1
+        ];
+
+        yield 'use trait (namespaced)' => [
+            "// File: src/file1.php\n<?php use N\T; class C { use T; }",
+            'N\T',
+            1
+        ];
+
+        yield 'use trait (namespaced & grouped)' => [
+            "// File: src/file1.php\n<?php use N\{T}; class C { use T; }",
+            'N\T',
+            1
+        ];
+
+        yield 'use trait (aliased)' => [
+            "// File: src/file1.php\n<?php use N\T as G; class C { use G; }",
+            'N\T',
+            1
+        ];
+    }
+}


### PR DESCRIPTION
* Index static properties without the $.

* Add static property indexer test

* Remove stray dump

* Index use statements and trait usings.

* -- Index trait usings as references
-- Added tests for trait usings for IndexedReferenceFinder
-- Added traits for TraitUseCaluseIndexer

* Coding standards

* change worse-reflection version requirement

* fix comments

* Index static properties without the $.

* Add static property indexer test

* Remove stray dump

* Index use statements and trait usings.

* -- Index trait usings as references
-- Added tests for trait usings for IndexedReferenceFinder
-- Added traits for TraitUseCaluseIndexer

* Coding standards

* change worse-reflection version requirement

* fix comments